### PR TITLE
feat: record multiple units of work

### DIFF
--- a/lib/reporter.ex
+++ b/lib/reporter.ex
@@ -87,8 +87,8 @@ defmodule BencheeAsync.Reporter do
   It is advised to mock the function that you wish to track and call this function within the mock.
   """
   @spec record() :: :ok
-  def record() do
-    GenServer.cast(__MODULE__, :record)
+  def record(n \\ 1) do
+    GenServer.cast(__MODULE__, {:record, n})
   end
 
   @doc """
@@ -161,17 +161,17 @@ defmodule BencheeAsync.Reporter do
   end
 
   @impl GenServer
-  def handle_cast(:record, %{ignoring?: true} = state),
+  def handle_cast({:record, _}, %{ignoring?: true} = state),
     do: {:noreply, state}
 
   @impl GenServer
-  def handle_cast(:record, state) do
+  def handle_cast({:record, n}, state) do
     now = current_time()
     diff = now - state.start_time
 
     samples =
       Map.update(state.samples, state.current_key, [diff], fn prev ->
-        [diff | prev]
+        List.duplicate(diff, n) ++ prev
       end)
 
     {:noreply, %{state | samples: samples, start_time: now}}

--- a/lib/reporter.ex
+++ b/lib/reporter.ex
@@ -85,8 +85,19 @@ defmodule BencheeAsync.Reporter do
   Records a unit of work done. Should be called each time a unit of work is performed.
 
   It is advised to mock the function that you wish to track and call this function within the mock.
+
+  ### Example
+
+  ```elixir
+  # record 1 unit of work
+  BencheeAsync.Reporter.record()
+
+  # record 5 units of work
+  BencheeAsync.Reporter.record(5)
+  ```
   """
   @spec record() :: :ok
+  @spec record(non_neg_integer()) :: :ok
   def record(n \\ 1) do
     GenServer.cast(__MODULE__, {:record, n})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule BencheeAsync.MixProject do
   def project do
     [
       app: :benchee_async,
-      version: "0.1.1#{@version_suffix}",
+      version: "0.1.2#{@version_suffix}",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/benchee_async_test.exs
+++ b/test/benchee_async_test.exs
@@ -109,7 +109,7 @@ defmodule BencheeAsyncTest do
             "case_slower" => fn input ->
               Task.start(fn ->
                 :timer.sleep(input)
-                Reporter.record()
+                Reporter.record(4)
               end)
 
               :timer.sleep(input * 2)


### PR DESCRIPTION
Allows recording of multiple units of work.
```elixir
BencheeAsync.Reporter.record()
BencheeAsync.Reporter.record(3) # 3 units recorded, each with the same length of time
```