### PR TITLE
chore: update env var to be prefixed, use semver prerelease format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         if: github.event_name == 'push'
         env:
           HEX_API_KEY: ${{ secrets.HEX_AUTH_TOKEN }}
-          PRERELEASE_VERSION: dev-${{ env.short_sha }}
+          BENCHEE_ASYNC_PRERELEASE_VERSION: dev.${{ env.short_sha }}
       - run: mix hex.publish --yes
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BencheeAsync.MixProject do
   use Mix.Project
 
-  @prerelease System.get_env("PRERELEASE_VERSION")
+  @prerelease System.get_env("BENCHEE_ASYNC_PRERELEASE_VERSION")
   @version_suffix if(@prerelease, do: "-#{@prerelease}", else: "")
   @gh_url "https://github.com/Ziinc/benchee_async"
   @lib_name "BencheeAsync"


### PR DESCRIPTION
This adds a prefix to the env var, and switches dev pre-releases to use semver